### PR TITLE
coderplus/copy-rename-maven-plugin#10 : Added the ability to skip

### DIFF
--- a/src/main/java/com/coderplus/plugins/CopyMojo.java
+++ b/src/main/java/com/coderplus/plugins/CopyMojo.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
@@ -88,6 +89,13 @@ extends AbstractMojo
 	@Parameter( property = "copy.ignoreFileNotFoundOnIncremental", defaultValue = "true" )
 	boolean ignoreFileNotFoundOnIncremental;
 
+	/**
+	 * Skip copy execution
+	 *
+	 * @since 1.1
+	 */
+	@Parameter( property = "copy.rename.skip", defaultValue = "false" )
+	boolean skip = false;
 
 	/**
 	 * @since 1.0
@@ -100,19 +108,24 @@ extends AbstractMojo
 
 	public void execute() throws MojoExecutionException
 	{
-		getLog().debug("Executing the copy-rename-maven-plugin");
-		if(fileSets!= null && fileSets.size() > 0){
-			for(FileSet fileSet: fileSets){
-				File srcFile = fileSet.getSourceFile();
-				File destFile = fileSet.getDestinationFile();
-				if(srcFile!=null){
-					copy(srcFile,destFile);
+		if(Boolean.FALSE.equals(skip)) {
+			getLog().debug("Executing the copy-rename-maven-plugin");
+
+			if(fileSets!= null && fileSets.size() > 0){
+				for(FileSet fileSet: fileSets){
+					File srcFile = fileSet.getSourceFile();
+					File destFile = fileSet.getDestinationFile();
+					if(srcFile!=null){
+						copy(srcFile,destFile);
+					}
 				}
+			} else if(sourceFile!= null){
+				copy(sourceFile,destinationFile);
+			} else{
+				getLog().info("No Files to process");
 			}
-		} else if(sourceFile!= null){
-			copy(sourceFile,destinationFile);
-		} else{
-			getLog().info("No Files to process");
+		} else {
+			getLog().info("Skipped the copy-rename-maven-plugin");
 		}
 	}
 

--- a/src/main/java/com/coderplus/plugins/CopyMojo.java
+++ b/src/main/java/com/coderplus/plugins/CopyMojo.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;

--- a/src/main/java/com/coderplus/plugins/RenameMojo.java
+++ b/src/main/java/com/coderplus/plugins/RenameMojo.java
@@ -88,6 +88,13 @@ extends AbstractMojo
 	@Parameter( property = "copy.ignoreFileNotFoundOnIncremental", defaultValue = "true" )
 	boolean ignoreFileNotFoundOnIncremental;
 
+	/**
+	 * Skip rename execution
+	 *
+	 * @since 1.1
+	 */
+	@Parameter( property = "copy.rename.skip", defaultValue = "false" )
+	boolean skip = false;
 
 	/**
 	 * @since 1.0
@@ -100,19 +107,23 @@ extends AbstractMojo
 
 	public void execute() throws MojoExecutionException
 	{
-		getLog().debug("Executing the copy-rename-maven-plugin");
-		if(fileSets!= null && fileSets.size() > 0){
-			for(FileSet fileSet: fileSets){
-				File srcFile = fileSet.getSourceFile();
-				File destFile = fileSet.getDestinationFile();
-				if(srcFile!=null){
-					copy(srcFile,destFile);
+		if(Boolean.FALSE.equals(skip)) {
+			getLog().debug("Executing the copy-rename-maven-plugin");
+			if (fileSets != null && fileSets.size() > 0) {
+				for (FileSet fileSet : fileSets) {
+					File srcFile = fileSet.getSourceFile();
+					File destFile = fileSet.getDestinationFile();
+					if (srcFile != null) {
+						copy(srcFile, destFile);
+					}
 				}
+			} else if (sourceFile != null) {
+				copy(sourceFile, destinationFile);
+			} else {
+				getLog().info("No Files to process");
 			}
-		} else if(sourceFile!= null){
-			copy(sourceFile,destinationFile);
-		} else{
-			getLog().info("No Files to process");
+		} else {
+			getLog().info("Skipped the copy-rename-maven-plugin");
 		}
 	}
 


### PR DESCRIPTION
This is something that has been raised already in issue #10 and would be useful for us to be able to skip plugin execution.

I have set the default to false to aid backward compatibility with existing users of the plugin.