### PR TITLE
Add flag to skip copy/rename when the src file does not exist

### DIFF
--- a/src/main/java/com/coderplus/plugins/CopyMojo.java
+++ b/src/main/java/com/coderplus/plugins/CopyMojo.java
@@ -63,6 +63,13 @@ extends AbstractMojo
 	 */
 	@Parameter( required = false )
 	private File destinationFile;
+	/**
+	 * Ignore copying this file if it does not exist
+	 * 
+	 * @since 1.1
+	 */
+	@Parameter( required = false )
+	private boolean ignoreFileIfNotExits;
 
 	/**
 	 * Collection of FileSets to work on (FileSet contains sourceFile and destinationFile). See <a href="./usage.html">Usage</a> for details.
@@ -88,7 +95,6 @@ extends AbstractMojo
 	@Parameter( property = "copy.ignoreFileNotFoundOnIncremental", defaultValue = "true" )
 	boolean ignoreFileNotFoundOnIncremental;
 
-
 	/**
 	 * @since 1.0
 	 */
@@ -105,21 +111,25 @@ extends AbstractMojo
 			for(FileSet fileSet: fileSets){
 				File srcFile = fileSet.getSourceFile();
 				File destFile = fileSet.getDestinationFile();
+				boolean ignoreFileIfNotExits = fileSet.getIgnoreFileIfNotExits();
 				if(srcFile!=null){
-					copy(srcFile,destFile);
+					copy(srcFile,destFile,ignoreFileIfNotExits);
 				}
 			}
 		} else if(sourceFile!= null){
-			copy(sourceFile,destinationFile);
+			copy(sourceFile,destinationFile,ignoreFileIfNotExits);
 		} else{
 			getLog().info("No Files to process");
 		}
 	}
 
-	private void copy(File srcFile,File destFile) throws MojoExecutionException{
+	private void copy(File srcFile,File destFile, boolean ignoreFileIfNotExits) throws MojoExecutionException{
 
 		if(!srcFile.exists()){
-			if(ignoreFileNotFoundOnIncremental && buildContext.isIncremental()){
+			if (ignoreFileIfNotExits){
+				getLog().info("Copying will be ignored because the file " + srcFile.getName() + " does not exist");
+			}
+			else if(ignoreFileNotFoundOnIncremental && buildContext.isIncremental()){
 				getLog().warn("sourceFile "+srcFile.getAbsolutePath()+ " not found during incremental build");
 			} else {
 				getLog().error("sourceFile "+srcFile.getAbsolutePath()+ " does not exist");
@@ -143,7 +153,6 @@ extends AbstractMojo
 				throw new MojoExecutionException("could not copy "+srcFile.getAbsolutePath()+" to "+destFile.getAbsolutePath());
 			}
 		}
-
 
 	}
 }

--- a/src/main/java/com/coderplus/plugins/FileSet.java
+++ b/src/main/java/com/coderplus/plugins/FileSet.java
@@ -28,6 +28,7 @@ public class FileSet {
 
 	private File sourceFile;
 	private File destinationFile;
+	private boolean ignoreFileIfNotExits;
 
 	public File getSourceFile() {
 		return sourceFile;
@@ -40,5 +41,11 @@ public class FileSet {
 	}
 	public void setDestinationFile(File destinationFile) {
 		this.destinationFile = destinationFile;
+	}
+	public boolean getIgnoreFileIfNotExits() {
+		return ignoreFileIfNotExits;
+	}
+	public void setIgnoreFileIfNotExits(boolean ignoreFileIfNotExits) {
+		this.ignoreFileIfNotExits = ignoreFileIfNotExits;
 	}
 }

--- a/src/main/java/com/coderplus/plugins/RenameMojo.java
+++ b/src/main/java/com/coderplus/plugins/RenameMojo.java
@@ -63,6 +63,13 @@ extends AbstractMojo
 	 */
 	@Parameter( required = false )
 	private File destinationFile;
+	/**
+	 * Ignore renaming this file if it does not exist
+	 * 
+	 * @since 1.1
+	 */
+	@Parameter( required = false )
+	private boolean ignoreFileIfNotExits;
 
 	/**
 	 * Collection of FileSets to work on (FileSet contains sourceFile and destinationFile). See <a href="./usage.html">Usage</a> for details.
@@ -105,21 +112,25 @@ extends AbstractMojo
 			for(FileSet fileSet: fileSets){
 				File srcFile = fileSet.getSourceFile();
 				File destFile = fileSet.getDestinationFile();
+				boolean ignoreFileIfNotExits = fileSet.getIgnoreFileIfNotExits();
 				if(srcFile!=null){
-					copy(srcFile,destFile);
+					copy(srcFile,destFile,ignoreFileIfNotExits);
 				}
 			}
 		} else if(sourceFile!= null){
-			copy(sourceFile,destinationFile);
+			copy(sourceFile,destinationFile,ignoreFileIfNotExits);
 		} else{
 			getLog().info("No Files to process");
 		}
 	}
 
-	private void copy(File srcFile,File destFile) throws MojoExecutionException{
+	private void copy(File srcFile,File destFile, boolean ignoreFileIfNotExits) throws MojoExecutionException{
 
 		if(!srcFile.exists()){
-			if(ignoreFileNotFoundOnIncremental && buildContext.isIncremental()){
+			if (ignoreFileIfNotExits){
+				getLog().info("Renaming will be ignored because the file " + srcFile.getName() + " does not exist");
+			}
+			else if(ignoreFileNotFoundOnIncremental && buildContext.isIncremental()){
 				getLog().warn("sourceFile "+srcFile.getAbsolutePath()+ " not found during incremental build");
 			} else {
 				getLog().error("sourceFile "+srcFile.getAbsolutePath()+ " does not exist");


### PR DESCRIPTION
Sometimes the file we want to copy or rename does not exist for various reasons. In this case, we should have the option to ignore the copy/rename. With the introduction of this flag, we can decide whether or not the build fails if the source file is absent.